### PR TITLE
Better timing retro_run() call

### DIFF
--- a/retrograde-app-shared/src/main/java/com/codebutler/retrograde/lib/retro/RetroThread.kt
+++ b/retrograde-app-shared/src/main/java/com/codebutler/retrograde/lib/retro/RetroThread.kt
@@ -1,13 +1,14 @@
 package com.codebutler.retrograde.lib.retro
 
-import java.util.*
+import java.util.LinkedList
 import kotlin.math.roundToLong
 import kotlin.system.measureNanoTime
 
 /** Handle periodic actions with improved accuracy. Core ideas taken from:
  *  https://github.com/LWJGL/lwjgl/blob/master/src/java/org/lwjgl/opengl/Sync.java */
 
-class RetroThread(private val cyclePeriod: Long, private val runnable: () -> Unit): Thread() {
+class RetroThread(private val cyclePeriod: Long, private val runnable: () -> Unit) : Thread() {
+
     companion object {
         const val NANOS_IN_SECOND = 1_000_000_000L
         const val SLEEP_SECURITY_THRESHOLD = 1_000_000 // We overestimate this value to make sure we are not sleeping too much
@@ -29,7 +30,7 @@ class RetroThread(private val cyclePeriod: Long, private val runnable: () -> Uni
     override fun run() {
         var startTime: Long
 
-        while(true) {
+        while (true) {
             startTime = System.nanoTime()
             runnable()
             accurateSleep(startTime + cyclePeriod)

--- a/retrograde-app-shared/src/main/java/com/codebutler/retrograde/lib/retro/RetroThread.kt
+++ b/retrograde-app-shared/src/main/java/com/codebutler/retrograde/lib/retro/RetroThread.kt
@@ -1,0 +1,59 @@
+package com.codebutler.retrograde.lib.retro
+
+import java.util.*
+import kotlin.math.roundToLong
+import kotlin.system.measureNanoTime
+
+/** Handle periodic actions with improved accuracy. Core ideas taken from:
+ *  https://github.com/LWJGL/lwjgl/blob/master/src/java/org/lwjgl/opengl/Sync.java */
+
+class RetroThread(private val cyclePeriod: Long, private val runnable: () -> Unit): Thread() {
+    companion object {
+        const val NANOS_IN_SECOND = 1_000_000_000L
+        const val SLEEP_SECURITY_THRESHOLD = 1_000_0000 // We overestimate this value to make sure we are not sleeping too much
+        const val MOVING_AVERAGE_SIZE = 10
+
+        fun fromFPS(fps: Double, runnable: () -> Unit): RetroThread {
+            val period = (1.0 / fps * NANOS_IN_SECOND).roundToLong()
+            return RetroThread(period, runnable)
+        }
+    }
+
+    private var lastSleepAverage = 0.0
+    private var lastYieldAverage = 0.0
+    private var lastMeasurement = 0L
+
+    var sleepDurationAverage = initMovingAverage()
+    var yieldDurationAverage = initMovingAverage()
+
+    override fun run() {
+        var startTime: Long
+
+        while(true) {
+            startTime = System.nanoTime()
+            runnable()
+            accurateSleep( startTime + cyclePeriod)
+        }
+    }
+
+    private fun accurateSleep(nextFrame: Long) {
+        while (System.nanoTime() < nextFrame - lastSleepAverage) {
+            lastMeasurement = measureNanoTime { sleep(1) }
+            lastSleepAverage = sleepDurationAverage(lastMeasurement) + SLEEP_SECURITY_THRESHOLD
+        }
+
+        while (System.nanoTime() < nextFrame - lastYieldAverage) {
+            lastMeasurement = measureNanoTime { yield() }
+            lastYieldAverage = yieldDurationAverage(lastMeasurement)
+        }
+    }
+
+    private fun initMovingAverage(): (Long) -> Double {
+        val list = LinkedList<Long>()
+        return {
+            list.add(it)
+            if (list.size > MOVING_AVERAGE_SIZE) list.removeFirst()
+            list.average()
+        }
+    }
+}

--- a/retrograde-app-shared/src/main/java/com/codebutler/retrograde/lib/retro/RetroThread.kt
+++ b/retrograde-app-shared/src/main/java/com/codebutler/retrograde/lib/retro/RetroThread.kt
@@ -10,7 +10,7 @@ import kotlin.system.measureNanoTime
 class RetroThread(private val cyclePeriod: Long, private val runnable: () -> Unit): Thread() {
     companion object {
         const val NANOS_IN_SECOND = 1_000_000_000L
-        const val SLEEP_SECURITY_THRESHOLD = 1_000_0000 // We overestimate this value to make sure we are not sleeping too much
+        const val SLEEP_SECURITY_THRESHOLD = 1_000_000 // We overestimate this value to make sure we are not sleeping too much
         const val MOVING_AVERAGE_SIZE = 10
 
         fun fromFPS(fps: Double, runnable: () -> Unit): RetroThread {
@@ -32,7 +32,7 @@ class RetroThread(private val cyclePeriod: Long, private val runnable: () -> Uni
         while(true) {
             startTime = System.nanoTime()
             runnable()
-            accurateSleep( startTime + cyclePeriod)
+            accurateSleep(startTime + cyclePeriod)
         }
     }
 


### PR DESCRIPTION
I've been trying to port retrograde to mobile and on my phone the fixedRateTimer was all over the place. I implemented something along the lines of what you linked and it looks much more robust.

I'm of course open to any suggestion.